### PR TITLE
Fix CI so it correctly.... breaks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
         os: [windows-latest]
       fail-fast: false
     steps:
-    - name: Setup ROS 2 and Build
     - uses: ros-tooling/setup-ros@master
     - uses: ros-tooling/action-ros-ci@master
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
     steps:
     - name: Setup ROS 2 and Build
-    - uses: ros-tooling/setup-ros@0.0.25 
-    - uses: ros-tooling/action-ros-ci@0.0.18 
-    with:
+    - uses: ros-tooling/setup-ros@master
+    - uses: ros-tooling/action-ros-ci@master
+      with:
         package-name: ros2_action_test
         target-ros2-distro: foxy
 


### PR DESCRIPTION
The CI file was not correctly formatted, which was causing a build break.
I fixed the CI file so it now builds.... and breaks.

(Upstream tooling is currently broken on tip of tree)